### PR TITLE
feat: add gh_org and gh_repo template parameters

### DIFF
--- a/.github/workflows/template-e2e-test.yaml
+++ b/.github/workflows/template-e2e-test.yaml
@@ -24,10 +24,22 @@ jobs:
     
     env:
       SCENARIO: ${{ matrix.scenario }}
+      REGISTRY: ghcr.io
+    
+    permissions:
+      contents: read
+      packages: write
     
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -13,3 +13,5 @@ cargo_generate_version = ">=0.18.0"
 project_name = { prompt = "Project name", type = "string", default = "example-app" }
 include_s3 = { prompt = "Include S3-compatible storage (MinIO/S3)?", type = "bool", default = false }
 target_namespace = { prompt = "Target namespace", type = "string", default = "default" }
+gh_org = { prompt = "GitHub organization/username", type = "string", default = "your-org" }
+gh_repo = { prompt = "GitHub repository name", type = "string", default = "rust-service" }

--- a/deploy/base/knative-service.yaml.liquid
+++ b/deploy/base/knative-service.yaml.liquid
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: service
           # Image will be updated by Flux ImageUpdateAutomation
-          image: ghcr.io/your-org/rust-service:latest # {"$imagepolicy": "flux-system:rust-service"}
+          image: ghcr.io/{{ gh_org }}/{{ gh_repo }}:latest # {"$imagepolicy": "flux-system:rust-service"}
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/deploy/flux/image-repository.yaml
+++ b/deploy/flux/image-repository.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rust-service
   namespace: flux-system
 spec:
-  image: ghcr.io/{{ github_org }}/{{ github_repo}}
+  image: ghcr.io/{{ gh_org }}/{{ gh_repo }}
   interval: 1m
   # Optional: For private container registries
   # secretRef:

--- a/examples/no-s3/deploy/flux/image-repository.yaml
+++ b/examples/no-s3/deploy/flux/image-repository.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rust-service
   namespace: flux-system
 spec:
-  image: ghcr.io//
+  image: ghcr.io/your-org/rust-service
   interval: 1m
   # Optional: For private container registries
   # secretRef:

--- a/examples/no-s3/scripts/generate-examples.sh
+++ b/examples/no-s3/scripts/generate-examples.sh
@@ -16,6 +16,8 @@ echo "Generating with-s3..."
 cargo generate --path "$REPO_DIR" \
   --name example-app-with-s3 \
   --define include_s3=true \
+  --define gh_org=your-org \
+  --define gh_repo=rust-service \
   --silent
 
 # Generate no-s3 scenario
@@ -23,6 +25,8 @@ echo "Generating no-s3..."
 cargo generate --path "$REPO_DIR" \
   --name example-app-no-s3 \
   --define include_s3=false \
+  --define gh_org=your-org \
+  --define gh_repo=rust-service \
   --silent
 
 # Move to examples directory

--- a/examples/with-s3/deploy/flux/image-repository.yaml
+++ b/examples/with-s3/deploy/flux/image-repository.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rust-service
   namespace: flux-system
 spec:
-  image: ghcr.io//
+  image: ghcr.io/your-org/rust-service
   interval: 1m
   # Optional: For private container registries
   # secretRef:

--- a/examples/with-s3/scripts/generate-examples.sh
+++ b/examples/with-s3/scripts/generate-examples.sh
@@ -16,6 +16,8 @@ echo "Generating with-s3..."
 cargo generate --path "$REPO_DIR" \
   --name example-app-with-s3 \
   --define include_s3=true \
+  --define gh_org=your-org \
+  --define gh_repo=rust-service \
   --silent
 
 # Generate no-s3 scenario
@@ -23,6 +25,8 @@ echo "Generating no-s3..."
 cargo generate --path "$REPO_DIR" \
   --name example-app-no-s3 \
   --define include_s3=false \
+  --define gh_org=your-org \
+  --define gh_repo=rust-service \
   --silent
 
 # Move to examples directory

--- a/scripts/generate-examples.sh
+++ b/scripts/generate-examples.sh
@@ -16,6 +16,8 @@ echo "Generating with-s3..."
 cargo generate --path "$REPO_DIR" \
   --name example-app-with-s3 \
   --define include_s3=true \
+  --define gh_org=your-org \
+  --define gh_repo=rust-service \
   --silent
 
 # Generate no-s3 scenario
@@ -23,6 +25,8 @@ echo "Generating no-s3..."
 cargo generate --path "$REPO_DIR" \
   --name example-app-no-s3 \
   --define include_s3=false \
+  --define gh_org=your-org \
+  --define gh_repo=rust-service \
   --silent
 
 # Move to examples directory

--- a/tests/e2e/scripts/04-verify-generation.sh
+++ b/tests/e2e/scripts/04-verify-generation.sh
@@ -7,18 +7,46 @@ INCLUDE_S3="${2}"
 echo "Installing cargo-generate..."
 cargo install cargo-generate --locked
 
-TEMP_DIR=$(mktemp -d)
-cd "$TEMP_DIR"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# Create a persistent directory for the generated template (not temp!)
+GENERATED_BASE="/tmp/e2e-generated"
+mkdir -p "$GENERATED_BASE"
+GENERATED_DIR="${GENERATED_BASE}/example-app-${SCENARIO}"
+
+# Remove any previous generation
+rm -rf "$GENERATED_DIR"
+
+cd "$GENERATED_BASE"
 
 echo "Generating template: ${SCENARIO}..."
+
+# Extract org and repo from GITHUB_REPOSITORY (format: owner/repo)
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  GH_ORG="${GITHUB_REPOSITORY%%/*}"
+  GH_REPO="${GITHUB_REPOSITORY##*/}"
+else
+  # Local development fallback
+  GH_ORG="your-org"
+  GH_REPO="rust-service"
+fi
+
+echo "  Using gh_org=${GH_ORG}, gh_repo=${GH_REPO}"
+
+# Generate with actual repository parameters for E2E testing
 cargo generate \
-  --path "$OLDPWD" \
+  --path "$PROJECT_ROOT" \
   --name "example-app-${SCENARIO}" \
   --define "include_s3=${INCLUDE_S3}" \
+  --define "gh_org=${GH_ORG}" \
+  --define "gh_repo=${GH_REPO}" \
   --silent
 
-GENERATED_DIR="${TEMP_DIR}/example-app-${SCENARIO}"
-REFERENCE_DIR="${OLDPWD}/examples/${SCENARIO}"
+REFERENCE_DIR="${PROJECT_ROOT}/examples/${SCENARIO}"
+
+# Save the generated directory path for later steps
+echo "$GENERATED_DIR" > "${SCRIPT_DIR}/.generated-dir-${SCENARIO}"
 
 if [ ! -d "$GENERATED_DIR" ]; then
   echo "ERROR: Template generation failed - directory not created"
@@ -84,7 +112,11 @@ if [ -n "$DIFF_OUTPUT" ]; then
 fi
 
 echo "✓ Template generation verified - output matches reference"
+echo "✓ Generated template saved at: ${GENERATED_DIR}"
+echo ""
+echo "Generated template will be used for E2E deployment with:"
+echo "  - gh_org: ${GH_ORG}"
+echo "  - gh_repo: ${GH_REPO}"
 
-# Cleanup
-cd "$OLDPWD"
-rm -rf "$TEMP_DIR"
+# Return to original directory (don't cleanup - we need generated template!)
+cd "$PROJECT_ROOT"

--- a/tests/e2e/scripts/05-deploy-reference.sh
+++ b/tests/e2e/scripts/05-deploy-reference.sh
@@ -7,7 +7,17 @@ CLUSTER_NAME="e2e-${SCENARIO}"
 REGISTRY_NAME="kind-registry-${SCENARIO}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-REFERENCE_DIR="${PROJECT_ROOT}/examples/${SCENARIO}"
+
+# Use the generated template (not the reference examples)
+GENERATED_DIR_FILE="${SCRIPT_DIR}/.generated-dir-${SCENARIO}"
+if [ -f "$GENERATED_DIR_FILE" ]; then
+  DEPLOY_DIR=$(cat "$GENERATED_DIR_FILE")
+  echo "Using generated template from: ${DEPLOY_DIR}"
+else
+  echo "ERROR: Generated template directory not found."
+  echo "Did you run 04-verify-generation.sh first?"
+  exit 1
+fi
 
 # Set registry port based on scenario
 if [[ "$SCENARIO" == "no-s3" ]]; then
@@ -86,27 +96,47 @@ else
     --dry-run=client -o yaml | kubectl apply -f -
 fi
 
-echo "Building Docker image from reference implementation..."
-cd "$REFERENCE_DIR"
-LOCAL_IMAGE="rust-service-${SCENARIO}:e2e"
-REGISTRY_IMAGE="localhost:${REGISTRY_PORT}/rust-service-${SCENARIO}:e2e"
-docker build -t "${LOCAL_IMAGE}" .
+echo "Building Docker image from generated template..."
+cd "$DEPLOY_DIR"
 
-echo "Tagging and pushing image to local registry..."
-docker tag "${LOCAL_IMAGE}" "${REGISTRY_IMAGE}"
-docker push "${REGISTRY_IMAGE}"
+# Use ghcr.io for E2E images if GITHUB_REPOSITORY is set (CI environment)
+# Otherwise fall back to local registry for local testing
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  REGISTRY="ghcr.io"
+  IMAGE_NAME="${GITHUB_REPOSITORY}"
+  IMAGE_TAG="e2e-${SCENARIO}-${GITHUB_SHA::7}"
+  FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+  
+  echo "Building and pushing to ghcr.io: ${FULL_IMAGE}"
+  docker build \
+    --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+    --label "org.opencontainers.image.description=E2E test image for ${SCENARIO}" \
+    --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+    -t "${FULL_IMAGE}" .
+  docker push "${FULL_IMAGE}"
+else
+  # Local development: use local registry
+  LOCAL_IMAGE="rust-service-${SCENARIO}:e2e"
+  REGISTRY_IMAGE="localhost:${REGISTRY_PORT}/rust-service-${SCENARIO}:e2e"
+  FULL_IMAGE="${REGISTRY_NAME}:5000/rust-service-${SCENARIO}:e2e"
+  
+  echo "Building for local registry: ${REGISTRY_IMAGE}"
+  docker build -t "${LOCAL_IMAGE}" .
+  docker tag "${LOCAL_IMAGE}" "${REGISTRY_IMAGE}"
+  docker push "${REGISTRY_IMAGE}"
+fi
 
 echo "Deploying via kubectl (simulating Flux)..."
 # Save original kustomization.yaml
-KUSTOMIZATION_FILE="${REFERENCE_DIR}/deploy/overlays/dev/kustomization.yaml"
+KUSTOMIZATION_FILE="${DEPLOY_DIR}/deploy/overlays/dev/kustomization.yaml"
 cp "$KUSTOMIZATION_FILE" "${KUSTOMIZATION_FILE}.backup"
 
 # Override namespace in kustomization to use test-app instead of example-app
-cd "${REFERENCE_DIR}/deploy/overlays/dev"
+cd "${DEPLOY_DIR}/deploy/overlays/dev"
 kustomize edit set namespace test-app
 
 # Build the kustomization, override service endpoints for E2E environment, and apply
-kubectl kustomize "${REFERENCE_DIR}/deploy/overlays/dev" | \
+kubectl kustomize "${DEPLOY_DIR}/deploy/overlays/dev" | \
   sed 's|http://minio:9000|http://minio.services.svc.cluster.local:9000|g' | \
   kubectl apply -f -
 
@@ -115,10 +145,12 @@ mv "${KUSTOMIZATION_FILE}.backup" "$KUSTOMIZATION_FILE"
 
 cd "${PROJECT_ROOT}"
 
-# Patch the image to use our e2e built image from local registry
+# The generated template already references the correct image repo,
+# but we need to update to the specific E2E tag we just pushed
+echo "Patching Knative service to use E2E image: ${FULL_IMAGE}"
 kubectl patch ksvc rust-service -n test-app --type='json' \
   -p="[
-    {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"${REGISTRY_NAME}:5000/rust-service-${SCENARIO}:e2e\"}
+    {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"${FULL_IMAGE}\"}
   ]"
 
 echo "Waiting for Knative Service to be ready..."

--- a/tests/e2e/scripts/99-cleanup.sh
+++ b/tests/e2e/scripts/99-cleanup.sh
@@ -17,4 +17,13 @@ kind delete cluster --name "${CLUSTER_NAME}" 2>/dev/null || true
 # Remove kubeconfig file
 rm -f "$KUBECONFIG_FILE"
 
+# Remove generated template directory marker and files
+GENERATED_DIR_FILE="${SCRIPT_DIR}/.generated-dir-${SCENARIO}"
+if [ -f "$GENERATED_DIR_FILE" ]; then
+  GENERATED_DIR=$(cat "$GENERATED_DIR_FILE")
+  echo "Cleaning up generated template: ${GENERATED_DIR}..."
+  rm -rf "$GENERATED_DIR" 2>/dev/null || true
+  rm -f "$GENERATED_DIR_FILE"
+fi
+
 echo "✓ Cleanup complete"


### PR DESCRIPTION
- Add gh_org and gh_repo parameters to cargo-generate.toml
- Update Knative service and Flux image repository to use template variables
- Configure E2E tests to push to ghcr.io instead of local registry
- Fix E2E flow to deploy generated templates with actual repo values
- Update examples generation script with new parameters